### PR TITLE
OCPBUGS-41179: Revert "Updating aws-kms-encryption-provider-container image to be consistent with ART for 4.18"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/sigs.k8s.io/aws-encryption-provider
 COPY . ./
 ENV GO111MODULE=on
@@ -7,7 +7,7 @@ RUN TAG=$(git rev-parse --short HEAD) && \
     "-w -s -X sigs.k8s.io/aws-encryption-provider/pkg/version.Version=$TAG" \
     -o bin/aws-encryption-provider cmd/server/main.go
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.access.redhat.com/ubi9:latest
 COPY --from=builder /go/src/sigs.k8s.io/aws-encryption-provider/bin/aws-encryption-provider /usr/bin/aws-encryption-provider
 ENTRYPOINT ["/usr/bin/aws-encryption-provider"]
 LABEL io.openshift.release.operator=true


### PR DESCRIPTION
This reverts commit 8989bdf8bb0334f25d59a3f00d374d7455cdc487.