### PR TITLE
NO-JIRA: Add OCP engineers to OWNERS for KMS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,11 @@ reviewers:
   - sjenning
   - enxebre
   - csrwng
+  - dgrisonnet
+  - swghosh
 approvers:
   - sjenning
   - enxebre
   - csrwng
+  - dgrisonnet
+  - swghosh


### PR DESCRIPTION
Add myself and @swghosh to the OWNERS as this repo is used in OCP for KMS support.