### PR TITLE
CNTRLPLANE-3380: Update OWNERS with HyperShift core team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,20 @@
 reviewers:
-  - sjenning
-  - enxebre
+  - bryan-cox
+  - clebs
   - csrwng
+  - devguyio
+  - enxebre
+  - jparrill
+  - muraee
+  - Nirshal
+  - sdminonne
+  - sjenning
 approvers:
-  - sjenning
-  - enxebre
+  - bryan-cox
   - csrwng
+  - devguyio
+  - enxebre
+  - jparrill
+  - muraee
+  - sjenning
+component: hypershift


### PR DESCRIPTION
## Summary
- Adds HyperShift core reviewers and approvers to align with the main hypershift repo
- New reviewers: `bryan-cox`, `clebs`, `devguyio`, `jparrill`, `muraee`, `Nirshal`, `sdminonne`
- New approvers: `bryan-cox`, `devguyio`, `jparrill`, `muraee`
- Added `component: hypershift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)